### PR TITLE
Django 1.9 compa

### DIFF
--- a/django_qbe/exports.py
+++ b/django_qbe/exports.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from future import standard_library
+standard_library.install_aliases()
+
 import csv
 import six
 from builtins import object, str
@@ -7,10 +10,7 @@ import collections
 import six
 from collections import OrderedDict as SortedDict
 from django.http import StreamingHttpResponse
-from future import standard_library
 from io import StringIO, BytesIO
-
-standard_library.install_aliases()
 
 
 __all__ = ("formats", )

--- a/django_qbe/forms.py
+++ b/django_qbe/forms.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+
 from builtins import range
 import collections
 from django import forms

--- a/django_qbe/operators.py
+++ b/django_qbe/operators.py
@@ -1,3 +1,6 @@
+from future import standard_library
+standard_library.install_aliases()
+
 from builtins import object
 from django.conf import settings
 from django.db import connections

--- a/django_qbe/savedqueries/admin.py
+++ b/django_qbe/savedqueries/admin.py
@@ -1,7 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.contrib import admin
-from django.contrib.admin.util import unquote
+from django.contrib.admin.utils import unquote
 try:
     from django.conf.urls import patterns, url
 except ImportError:

--- a/django_qbe/savedqueries/models.py
+++ b/django_qbe/savedqueries/models.py
@@ -1,3 +1,6 @@
+from future import standard_library
+standard_library.install_aliases()
+
 from builtins import object
 import pickle
 from django.db import models

--- a/django_qbe/templatetags/qbe_tags.py
+++ b/django_qbe/templatetags/qbe_tags.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+
 from builtins import range
 from past.utils import old_div
 from django import template

--- a/django_qbe/utils.py
+++ b/django_qbe/utils.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+
 from past.builtins import cmp
 from builtins import zip
 from builtins import filter

--- a/django_qbe/widgets.py
+++ b/django_qbe/widgets.py
@@ -1,5 +1,8 @@
-from builtins import object
 # -*- coding: utf-8 -*-
+from future import standard_library
+standard_library.install_aliases()
+
+from builtins import object
 from django.forms.utils import flatatt
 from django.forms.widgets import MultiWidget, Select, TextInput, Widget
 from django.utils.safestring import mark_safe

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     zip_safe=False,
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['django-picklefield'],
+    install_requires=['django-picklefield', 'future'],
 )


### PR DESCRIPTION
Changes:
- Call `standard_library.install_aliases()` before imports from `builtins` happen
- `django.contrib.admin.util` now called `django.contrib.admin.utils` in Django 1.9